### PR TITLE
chore(rebrand): metadata & NOTICE (no code changes)

### DIFF
--- a/NOTICE.md
+++ b/NOTICE.md
@@ -1,0 +1,9 @@
+# NOTICE
+
+This repository is an **independent fork** of upstream Uniswap code and is **not affiliated with or endorsed by Uniswap**.
+
+- Upstream source: git@github.com:Uniswap/sdk-core.git
+- Copyrights and licenses remain with their respective owners.
+- See `LICENSE` for full licensing terms of this repository. Some upstream components may be under different licenses; consult upstream for details.
+
+This fork primarily changes branding and build/release metadata at this stage. Functional changes (if any) will be documented in release notes and pull requests.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+> **Independent fork** — not affiliated with Uniswap. See NOTICE.md.
+
 # @uniswap/sdk-core - Now at `Uniswap/sdks`
 
 All versions after 4.2.0 of this SDK can be found in the [SDK monorepo](https://github.com/Uniswap/sdks/tree/main/sdks/sdk-core)! Please file all future issues, PR’s, and discussions there.

--- a/package.json
+++ b/package.json
@@ -2,13 +2,16 @@
   "name": "@uniswap/sdk-core",
   "license": "MIT",
   "version": "4.2.0",
-  "description": "⚒️ An SDK for building applications on top of Uniswap V3",
+  "description": "Primea fork — independent fork of upstream Uniswap repo",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
   "files": [
     "dist"
   ],
-  "repository": "https://github.com/Uniswap/uniswap-sdk-core.git",
+  "repository": {
+    "type": "git",
+    "url": "git+ssh://git@github.com/primeanetwork/sdk-core.git"
+  },
   "keywords": [
     "uniswap",
     "ethereum"
@@ -40,5 +43,9 @@
     "printWidth": 120,
     "semi": false,
     "singleQuote": true
-  }
+  },
+  "bugs": {
+    "url": "https://github.com/primeanetwork/sdk-core/issues"
+  },
+  "homepage": "https://github.com/primeanetwork/sdk-core#readme"
 }


### PR DESCRIPTION
Adds `NOTICE.md`, injects an in-repo banner in `README.md`, and updates `package.json` metadata fields to point to `primeanetwork/sdk-core`. **No product code changes.**